### PR TITLE
Fix out-of-bounds vector accesses

### DIFF
--- a/src/papilo/core/Presolve.hpp
+++ b/src/papilo/core/Presolve.hpp
@@ -1120,7 +1120,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
 
       for( ; k != start; ++k )
       {
-         result = probUpdate.applyTransaction( &reds[k], &reds[k + 1] );
+         result = probUpdate.applyTransaction( &reds[k], &reds.data()[k + 1] );
          if( result == ApplyResult::kApplied )
             ++stats.ntsxapplied;
          else if( result == ApplyResult::kRejected )
@@ -1128,12 +1128,12 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
          else if( result == ApplyResult::kInfeasible )
             return std::make_pair( -1, -1 );
          else if( result == ApplyResult::kPostponed )
-            postponedReductions.emplace_back( &reds[k], &reds[k + 1] );
+            postponedReductions.emplace_back( &reds[k], &reds.data()[k + 1] );
 
          ++nbtsxTotal;
       }
 
-      result = probUpdate.applyTransaction( &reds[start], &reds[end] );
+      result = probUpdate.applyTransaction( &reds[start], &reds.data()[end] );
       if( result == ApplyResult::kApplied )
          ++stats.ntsxapplied;
       else if( result == ApplyResult::kRejected )
@@ -1141,7 +1141,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
       else if( result == ApplyResult::kInfeasible )
          return std::make_pair( -1, -1 );
       else if( result == ApplyResult::kPostponed )
-         postponedReductions.emplace_back( &reds[start], &reds[end] );
+         postponedReductions.emplace_back( &reds[start], &reds.data()[end] );
 
       k = end;
       ++nbtsxTotal;
@@ -1149,7 +1149,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
 
    for( ; k != static_cast<int>( reds.size() ); ++k )
    {
-      result = probUpdate.applyTransaction( &reds[k], &reds[k + 1] );
+      result = probUpdate.applyTransaction( &reds[k], &reds.data()[k + 1] );
       if( result == ApplyResult::kApplied )
          ++stats.ntsxapplied;
       else if( result == ApplyResult::kRejected )
@@ -1157,7 +1157,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
       else if( result == ApplyResult::kInfeasible )
          return std::make_pair( -1, -1 );
       else if( result == ApplyResult::kPostponed )
-         postponedReductions.emplace_back( &reds[k], &reds[k + 1] );
+         postponedReductions.emplace_back( &reds[k], &reds.data()[k + 1] );
 
       ++nbtsxTotal;
    }

--- a/src/papilo/core/postsolve/Postsolve.hpp
+++ b/src/papilo/core/postsolve/Postsolve.hpp
@@ -382,7 +382,7 @@ Postsolve<REAL>::undo( const Solution<REAL>& reducedSolution,
          if( originalSolution.basisAvailabe )
             originalSolution.rowBasisStatus[indices[first]] =
                 VarBasisStatus::BASIC;
-         if( types[i - 1] == ReductionType::kSubstitutedColWithDual )
+         if( i >= 1 && types[i - 1] == ReductionType::kSubstitutedColWithDual )
             continue;
          break;
          // the remaining Types are used as additional information for other


### PR DESCRIPTION
I am looking into adding a papilo package to the Fedora Linux distribution, for use by soplex.  Fedora builds its packages with `-D_GLIBCXX_ASSERTIONS`.  This enables vector bounds checks, among other things.  The soplex test suite caused the vector bounds check assertions to fail in several cases, all fixed by this PR.

In the Presolve.hpp case, all you want is a pointer to use for comparisons.  If `k` or `end` are sufficiently large, there is no such vector element, so the assertion triggers.  Using the results of `data()` instead allows a pointer to be computed without making `operator[]` unhappy.

In the Postsolve.hpp case, `i` can be zero.  This is already handled for the `kCoefficientChange` case, so do the same for the `kRedundantRow` case.