### PR TITLE
Avoid calling operator[] beyond the ends of vectors

### DIFF
--- a/src/duplicates.cpp
+++ b/src/duplicates.cpp
@@ -219,7 +219,8 @@ compute_row_and_column_permutation( const Problem<double>& prob, bool verbose )
                 int row = rowperm[i];
                 int start = csrstarts[row];
                 int end = csrstarts[row + 1];
-                pdqsort( &csrvals[start], &csrvals[end], comp_rowvals );
+                const auto csrvals_ptr = csrvals.data();
+                pdqsort( &csrvals_ptr[start], &csrvals_ptr[end], comp_rowvals );
 
                 Hasher<uint64_t> hasher( end - start );
                 for( int k = start; k < end; ++k )
@@ -285,7 +286,8 @@ compute_row_and_column_permutation( const Problem<double>& prob, bool verbose )
                 int col = colperm[i];
                 int start = cscstarts[col];
                 int end = cscstarts[col + 1];
-                pdqsort( &cscvals[start], &cscvals[end], comp_colvals );
+                const auto cscvals_ptr = cscvals.data();
+                pdqsort( &cscvals_ptr[start], &cscvals_ptr[end], comp_colvals );
 
                 Hasher<uint64_t> hasher( end - start );
                 for( int k = start; k < end; ++k )
@@ -807,7 +809,8 @@ compute_instancehash( const Problem<double>& prob )
                 int row = rowperm[i];
                 int start = csrstarts[row];
                 int end = csrstarts[row + 1];
-                pdqsort( &csrvals[start], &csrvals[end], comp_rowvals );
+                const auto csrvals_ptr = csrvals.data();
+                pdqsort( &csrvals_ptr[start], &csrvals_ptr[end], comp_rowvals );
 
                 Hasher<uint64_t> hasher( end - start );
                 for( int k = start; k < end; ++k )
@@ -874,7 +877,8 @@ compute_instancehash( const Problem<double>& prob )
                 int col = colperm[i];
                 int start = cscstarts[col];
                 int end = cscstarts[col + 1];
-                pdqsort( &cscvals[start], &cscvals[end], comp_colvals );
+                const auto cscvals_ptr = cscvals.data();
+                pdqsort( &cscvals_ptr[start], &cscvals_ptr[end], comp_colvals );
 
                 Hasher<uint64_t> hasher( end - start );
                 for( int k = start; k < end; ++k )

--- a/src/papilo/core/Presolve.hpp
+++ b/src/papilo/core/Presolve.hpp
@@ -1110,6 +1110,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
    int nbtsxTotal = 0;
 
    const auto& reds = reductions_.getReductions();
+   const auto reds_ptr = reds.data();
 
    msg.detailed( "Presolver {} applying \n", presolvers[p]->getName() );
 
@@ -1120,7 +1121,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
 
       for( ; k != start; ++k )
       {
-         result = probUpdate.applyTransaction( &reds[k], &reds[k + 1] );
+         result = probUpdate.applyTransaction( &reds_ptr[k], &reds_ptr[k + 1] );
          if( result == ApplyResult::kApplied )
             ++stats.ntsxapplied;
          else if( result == ApplyResult::kRejected )
@@ -1128,12 +1129,12 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
          else if( result == ApplyResult::kInfeasible )
             return std::make_pair( -1, -1 );
          else if( result == ApplyResult::kPostponed )
-            postponedReductions.emplace_back( &reds[k], &reds[k + 1] );
+            postponedReductions.emplace_back( &reds_ptr[k], &reds_ptr[k + 1] );
 
          ++nbtsxTotal;
       }
 
-      result = probUpdate.applyTransaction( &reds[start], &reds[end] );
+      result = probUpdate.applyTransaction( &reds_ptr[start], &reds_ptr[end] );
       if( result == ApplyResult::kApplied )
          ++stats.ntsxapplied;
       else if( result == ApplyResult::kRejected )
@@ -1141,7 +1142,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
       else if( result == ApplyResult::kInfeasible )
          return std::make_pair( -1, -1 );
       else if( result == ApplyResult::kPostponed )
-         postponedReductions.emplace_back( &reds[start], &reds[end] );
+         postponedReductions.emplace_back( &reds_ptr[start], &reds_ptr[end] );
 
       k = end;
       ++nbtsxTotal;
@@ -1149,7 +1150,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
 
    for( ; k != static_cast<int>( reds.size() ); ++k )
    {
-      result = probUpdate.applyTransaction( &reds[k], &reds[k + 1] );
+      result = probUpdate.applyTransaction( &reds_ptr[k], &reds_ptr[k + 1] );
       if( result == ApplyResult::kApplied )
          ++stats.ntsxapplied;
       else if( result == ApplyResult::kRejected )
@@ -1157,7 +1158,7 @@ Presolve<REAL>::applyReductions( int p, const Reductions<REAL>& reductions_,
       else if( result == ApplyResult::kInfeasible )
          return std::make_pair( -1, -1 );
       else if( result == ApplyResult::kPostponed )
-         postponedReductions.emplace_back( &reds[k], &reds[k + 1] );
+         postponedReductions.emplace_back( &reds_ptr[k], &reds_ptr[k + 1] );
 
       ++nbtsxTotal;
    }

--- a/src/papilo/core/SparseStorage.hpp
+++ b/src/papilo/core/SparseStorage.hpp
@@ -694,10 +694,12 @@ SparseStorage<REAL>::compress( const Vec<int>& rowsize, const Vec<int>& colsize,
                // move values and columns
                assert( start >= offset );
 
-               std::move( &values[start], &values[end],
-                          &values[start - offset] );
-               std::move( &columns[start], &columns[end],
-                          &columns[start - offset] );
+               const auto values_ptr = values.data();
+               const auto columns_ptr = columns.data();
+               std::move( &values_ptr[start], &values_ptr[end],
+                          &values_ptr[start - offset] );
+               std::move( &columns_ptr[start], &columns_ptr[end],
+                          &columns_ptr[start - offset] );
 
                rowranges[rowcount].start -= offset;
                rowranges[rowcount].end -= offset;


### PR DESCRIPTION
I was running into an assertion failure when papilo is compiled with `-D_GLIBCXX_ASSERTIONS` (which is enabled for the [Arch Linux package](https://archlinux.org/packages/community/x86_64/papilo/)). The assertion was triggered by using `&reds[end]` to get a pointer to one beyond the end of a range. While this would be valid if `reds` were an array or pointer, it is undefined behavior to call `operator[]` outside the bounds of a vector.

Failing example:
```
NAME          ClpDefau
ROWS
 N  OBJROW
 E  R0000000
COLUMNS
    C0000000  OBJROW    -1.
    C0000000  R0000000  1.
    C0000001  R0000000  1.
    C0000002  R0000000  1.
    C0000003  R0000000  1.
RHS
    RHS       R0000000  1.
BOUNDS
 BV BOUND     C0000000  1.
 BV BOUND     C0000001  1.
 BV BOUND     C0000002  1.
 BV BOUND     C0000003  1.
ENDATA
```

When compiled with `-D_GLIBCXX_ASSERTIONS`, `papilo presolve -f bug.mps` produced an assertion failure:
```
PaPILO version 2.1.3 [mode: debug][Solvers: SCIP][GitHash: 690f78c]
Copyright (C) 2020-2022 Zuse Institute Berlin (ZIB)

External libraries: 
  Boost    1.81.0 	(https://www.boost.org/)
  TBB            	Thread building block https://github.com/oneapi-src/oneTBB developed by Intel
  GMP      6.2.1  	GNU Multiple Precision Arithmetic Library developed by T. Granlund (gmplib.org)
  SCIP     8.0.3 	Mixed Integer Programming Solver developed at Zuse Institute Berlin (scip.zib.de) [GitHash: NoGitInfo]

reading took 0.000217 seconds
Numerical Statistics:
 Matrix range    [1e+00,1e+00]
 Objective range [1e+00,1e+00]
 Bounds range    [1e+00,1e+00]
 RHS range       [1e+00,1e+00]
 Dynamism Variables: 1e+00
 Dynamism Rows     : 1e+00

starting presolve of problem bug.mps:
  rows:     1
  columns:  4
  int. columns:  4
  cont. columns:  0
  nonzeros: 4

round 0   ( Trivial  ):    0 del cols,    0 del rows,    0 chg bounds,    0 chg sides,    0 chg coeffs,    0 tsx applied,    0 tsx conflicts
/usr/include/c++/12.2.1/bits/stl_vector.h:1142: std::vector<_Tp, _Alloc>::const_reference std::vector<_Tp, _Alloc>::operator[](size_type) const [with _Tp = papilo::Reduction<double>; _Alloc = std::allocator<papilo::Reduction<double> >; const_reference = const papilo::Reduction<double>&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```

This pull request fixes this issue by using `.data()` to convert the vector into a pointer when necessary.