### PR TITLE
Fix sequence point violation in test code

### DIFF
--- a/test/papilo/presolve/ParallelRowDetectionTest.cpp
+++ b/test/papilo/presolve/ParallelRowDetectionTest.cpp
@@ -1214,7 +1214,7 @@ setupProblemParallelRowWithMixed( bool firstRowEquation, double lhsIneq,
    pb.setColNameAll( columnNames );
    pb.setProblemName( "matrix with parallel inequalities (0 and 2)" );
    Problem<double> problem = pb.build();
-   int i = firstRowEquation ? i = 0 : i = 2;
+   int i = firstRowEquation ? 0 : 2;
    problem.getConstraintMatrix().modifyLeftHandSide( i, num, rhs[i] );
    return problem;
 }


### PR DESCRIPTION
Fixes this gcc warning:
```
/builddir/build/BUILD/papilo-2.1.3/test/papilo/presolve/ParallelRowDetectionTest.cpp: In function 'papilo::Problem<double> setupProblemParallelRowWithMixed(bool, double, double, double, double)':
/builddir/build/BUILD/papilo-2.1.3/test/papilo/presolve/ParallelRowDetectionTest.cpp:1217:33: warning: operation on 'i' may be undefined [-Wsequence-point]
 1217 |    int i = firstRowEquation ? i = 0 : i = 2;
      |                               ~~^~~
```