### PR TITLE
Avoid out-of-bounds vector accesses

### DIFF
--- a/src/papilo/core/SparseStorage.hpp
+++ b/src/papilo/core/SparseStorage.hpp
@@ -311,9 +311,9 @@ class SparseStorage
       if( i != rowranges[row].end )
       {
          indbuffer.insert( indbuffer.end(), &columns[i],
-                           &columns[rowranges[row].end] );
+                           &columns.data()[rowranges[row].end] );
          valbuffer.insert( valbuffer.end(), &values[i],
-                           &values[rowranges[row].end] );
+                           &values.data()[rowranges[row].end] );
       }
       else
       {


### PR DESCRIPTION
The Fedora Linux distribution builds its packages with `-D_GLIBCXX_ASSERTIONS` in the build flags, which results in the C++ library checking vector bounds at runtime.  While attempting to build scip 8.1.0 on top of soplex 6.0.4 and papilo 2.1.4, one of the scip tests (MIP-pscost_proporbitope-blend2.mps) triggered a vector bounds assertion.

```
/usr/include/c++/13/bits/stl_vector.h:1125: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = int; _Alloc = std::allocator<int>; reference = int&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```

GDB shows that the issue occurs in `papilo::SparseStorage::changeRow`.  When `rowranges[row].end == columns.size()`, then the `operator[]` method of `std::vector` is called on an invalid index.  That operator returns a reference to the indicated vector member, which doesn't exist in this case.  This PR does simple pointer arithmetic instead to get the address of interest.