### PR TITLE
Avoid out-of-bounds array access

### DIFF
--- a/src/papilo/presolvers/ParallelColDetection.hpp
+++ b/src/papilo/presolvers/ParallelColDetection.hpp
@@ -588,13 +588,16 @@ ParallelColDetection<REAL>::execute( const Problem<REAL>& problem,
           bool flag_b_integer = cflags[b].test( ColFlag::kIntegral );
           if( flag_a_integer != flag_b_integer )
              return !flag_a_integer;
+          SparseVectorView<REAL> coeffs_a = constMatrix.getColumnCoefficients( a );
+          SparseVectorView<REAL> coeffs_b = constMatrix.getColumnCoefficients( b );
+          REAL coeff_a = (coeffs_a.getLength() > 0) ? coeffs_a.getValues()[0] : (REAL)0;
+          REAL coeff_b = (coeffs_b.getLength() > 0) ? coeffs_b.getValues()[0] : (REAL)0;
           return // sort by scale factor
               abs( obj[a] ) < abs( obj[b] ) ||
               // sort by scale factor if obj is zero
               ( abs( obj[a] ) == abs( obj[b] ) && obj[a] == 0 &&
                 determineOderingForZeroObj(
-                    constMatrix.getColumnCoefficients( a ).getValues()[0],
-                    constMatrix.getColumnCoefficients( b ).getValues()[0],
+                    coeff_a, coeff_b,
                     colperm[a], colperm[b] ) ) ||
               // sort by permutation
               ( abs( obj[a] ) == abs( obj[b] ) && obj[a] != 0 &&


### PR DESCRIPTION
This is my attempt at a fix for https://github.com/scipopt/papilo/issues/47.  It avoids reading element 0 of an empty array.  If that array should not be empty in the first place, then some other fix is needed.