### PR TITLE
Fix inifnity constants in VeriPB interface

### DIFF
--- a/src/papilo/verification/VeriPb.hpp
+++ b/src/papilo/verification/VeriPb.hpp
@@ -1764,9 +1764,9 @@ class VeriPb : public CertificateInterface<REAL>
          for(int i=0; i<row_data.getLength(); i++)
          {
             int index = row_data.getIndices()[i];
-            if( index == col || stored_objective.coefficients[index]  == -INFINITY )
+            if( index == col || stored_objective.coefficients[index]  == -std::numeric_limits<REAL>::infinity() )
                continue;
-            if(stored_objective.coefficients[index]  == INFINITY)
+            if(stored_objective.coefficients[index]  == std::numeric_limits<REAL>::infinity())
             {
                offset -= row_data.getValues()[i];
                continue;
@@ -1891,9 +1891,9 @@ class VeriPb : public CertificateInterface<REAL>
             for( int i = 0; i < row_data.getLength(); i++ )
             {
                int index = row_data.getIndices()[i];
-               if( index == col || stored_objective.coefficients[index]  == -INFINITY  )
+               if( index == col || stored_objective.coefficients[index]  == -std::numeric_limits<REAL>::infinity()  )
                   continue;
-               if(stored_objective.coefficients[index]  == INFINITY)
+               if(stored_objective.coefficients[index]  == std::numeric_limits<REAL>::infinity())
                {
                   offset -= row_data.getValues()[i];
                   continue;
@@ -2366,9 +2366,9 @@ class VeriPb : public CertificateInterface<REAL>
          }
       for(int i=0; i<equality.getLength(); i++)
       {
-         if( indices[i] == sub_col || stored_objective.coefficients[indices[i]]  == -INFINITY)
+         if( indices[i] == sub_col || stored_objective.coefficients[indices[i]]  == -std::numeric_limits<REAL>::infinity())
             continue;
-         if( stored_objective.coefficients[indices[i]]  == INFINITY )
+         if( stored_objective.coefficients[indices[i]]  == std::numeric_limits<REAL>::infinity() )
          {
             stored_objective.offset -= factor * values[i];
             continue;


### PR DESCRIPTION
The float constant `INFINITY` cannot be converted to the `Rational` type, which leads to a runtime error when attempting to compare coefficients with `INFINITY`, as seen below.
The instance used is available [in the RoundingSAT repository](https://gitlab.com/MIAOresearch/software/roundingsat/-/blob/master/test/instances/opb/opt/air01.opb?ref_type=heads).

```
❯ ./papilo presolve -a r -p ../../settings/verification.set -f ~/Git/roundingsat/test/instances/opb/opt/air01.opb
PaPILO version 2.2.2 [mode: debug][Solvers: none][GitHash: 053ce67f]
Copyright (C) 2020-2023 Zuse Institute Berlin (ZIB)

External libraries:
  Boost    1.83.0 	 (https://www.boost.org/)
  TBB            	 Thread building block https://github.com/oneapi-src/oneTBB developed by Intel
  GMP      6.3.0  	 GNU Multiple Precision Arithmetic Library developed by T. Granlund (gmplib.org)

reading took 0.0313 seconds
Numerical Statistics:
 Matrix range    [1e+00,1e+00]
 Objective range [1e+02,7e+03]
 Bounds range    [1e+00,1e+00]
 RHS range       [1e+00,1e+00]
 Dynamism Variables: 1e+00
 Dynamism Rows     : 1e+00
set verification_with_VeriPB = 1

starting presolve of problem /home/christoph/Git/roundingsat/test/instances/opb/opt/air01.opb with dual-postsolve de-activated
  rows:     23
  columns:  771
  int. columns:  771
  cont. columns:  0
  nonzeros: 4215

round 0   ( Trivial  ):    0 del cols,    0 del rows,    0 chg bounds,    0 chg sides,    0 chg coeffs,    0 tsx applied,    0 tsx conflicts
[1]    546276 floating point exception (core dumped)  ./papilo presolve -a r -p ../../settings/verification.set -f
```