### PR TITLE
Fix compilation error in Solution class constructor

### DIFF
--- a/src/papilo/core/Solution.hpp
+++ b/src/papilo/core/Solution.hpp
@@ -81,9 +81,9 @@ class Solution
 )
        : type( SolutionType::kPrimalDual ),
          primal( std::move( primal_values ) ),
-         dual( std::move( dual_values ),
+         dual( std::move( dual_values ) ),
          reducedCosts( std::move( reduced_values ) ),
-         slack( std::move( slack_values ) ) ),
+         slack( std::move( slack_values ) ),
          basisAvailabe( basisAvailabe_value ),
          varBasisStatus( std::move( var_basis_status )),
          rowBasisStatus( std::move( row_basis_status ))


### PR DESCRIPTION

This PR fixes a compilation error in the constructor of Solution class.   All the member variables are public, so initializing them individually works fine, but it would be cleaner to have the constructor working. 