### PR TITLE
Implement total time limit for a hard stop

### DIFF
--- a/src/papilo/core/PresolveOptions.hpp
+++ b/src/papilo/core/PresolveOptions.hpp
@@ -112,6 +112,7 @@ struct PresolveOptions
 
    double tlim = std::numeric_limits<double>::max();
 
+   double totaltlim = std::numeric_limits<double>::max();
 
    bool verification_with_VeriPB = false;
 
@@ -182,6 +183,8 @@ struct PresolveOptions
                              "times the number of rows or columns are active",
                              compressfac, 0.0, 1.0 );
       paramSet.addParameter( "presolve.tlim", "time limit for presolve", tlim,
+                             0.0 );
+      paramSet.addParameter( "presolve.totaltlim", "total time limit for presolve including the applying the reductions", totaltlim,
                              0.0 );
       paramSet.addParameter( "presolve.minabscoeff",
                              "minimum absolute coefficient value allowed in "


### PR DESCRIPTION

Time limit set in the parameters are not honored. This is because the application of found reduction can take a lot of time, for example, Sparsify takes quite a bit of time (In degme.mps file it takes 60 seconds to just apply sparsify reductions while the entire presolve takes just a couple of seconds).   It is impossible to predict apriori how long it would take for reductions to be applied.  This makes it hard to integrate the presolver in a solver where the user set time limits have to be honored. 

This PR introduces a new parameter called totaltlim, which is used to ignore the reductions after the hard time limit is reached.   

**Before this PR** 
```
./bin/papilo presolve -f degme.mps -r reduced_degme.mps --presolve.tlim=5
PaPILO version 2.4.4 [mode: optimized][Solvers: none][GitHash: f77cf7f6]
Copyright (C) 2020-2025 Zuse Institute Berlin (ZIB)

External libraries: 
  Boost    1.85.0        (https://www.boost.org/)
  TBB      2022.2        Thread building block https://github.com/oneapi-src/oneTBB developed by Intel

reading took 10.3 seconds
Numerical Statistics:
 Matrix range    [5e-01,5e+00]
 Objective range [5e-01,2e+00]
 Bounds range    [0e+00,0e+00]
 RHS range       [4e-15,8e+06]
 Dynamism Variables: 1e+01
 Dynamism Rows     : 1e+01
set presolve.tlim = 5
Please turn off the presolvers substitution and sparsify and componentsdetection to use dual-postsolving
Continuing without dual-presolve

starting presolve of problem degme.mps with dual-postsolve de-activated
  rows:     185501
  columns:  659415
  int. columns:  0
  cont. columns:  659415
  nonzeros: 8127528

round 0   ( Trivial  ):    0 del cols,    0 del rows,    0 chg bounds,    0 chg sides,    0 chg coeffs,    0 tsx applied,    0 tsx conflicts
round 1   (   Fast   ):    0 del cols,    0 del rows, 624079 chg bounds,    0 chg sides,    0 chg coeffs, 1248158 tsx applied,    0 tsx conflicts
round 2   (Exhaustive):    0 del cols,    0 del rows, 669661 chg bounds,    0 chg sides,    0 chg coeffs, 1387872 tsx applied,    0 tsx conflicts
activating delayed presolvers
round 3   (  Final   ):    0 del cols,    0 del rows, 673671 chg bounds, 31766 chg sides, 558322 chg coeffs, 1456533 tsx applied,    0 tsx conflicts

          presolver     nb calls   success calls(%)    nb transactions     tsx applied(%)  execution time(s) 
       colsingleton            3                0.0                  0                0.0              0.000
    coefftightening            0                0.0                  0                0.0              0.000
        propagation            3              100.0            1398390              100.0              0.118
      fixcontinuous            1                0.0                  0                0.0              0.005
      simpleprobing            0                0.0                  0                0.0              0.000
       parallelrows            1                0.0                  0                0.0              0.066
       parallelcols            1                0.0                  0                0.0              0.169
           stuffing            1                0.0                  0                0.0              0.001
            dualfix            1                0.0                  0                0.0              0.050
       simplifyineq            0                0.0                  0                0.0              0.000
        doubletoneq            1                0.0                  0                0.0              0.010
            implint            0                0.0                  0                0.0              0.000
             domcol            1                0.0                  0                0.0              0.080
          dualinfer            1                0.0                  0                0.0              0.511
            probing            0                0.0                  0                0.0              0.000
       substitution            1                0.0                  0                0.0              0.478
           sparsify            1              100.0              58143              100.0              0.631

reduced problem:
  reduced rows:     185501
  reduced columns:  659415
  reduced int. columns:  0
  reduced cont. columns:  659415
  reduced nonzeros: 8092932

presolving finished after 59.714 seconds

reduced problem written to reduced_degme.mps in 3.320 seconds
```

**With this PR**
```
./bin/papilo presolve -f degme.mps -r reduced_degme.mps --presolve.tlim=5 --presolve.totaltlim=10
PaPILO version 2.4.4 [mode: optimized][Solvers: none][GitHash: f77cf7f6]
Copyright (C) 2020-2025 Zuse Institute Berlin (ZIB)

External libraries: 
  Boost    1.85.0        (https://www.boost.org/)
  TBB      2022.2        Thread building block https://github.com/oneapi-src/oneTBB developed by Intel

reading took 10.3 seconds
Numerical Statistics:
 Matrix range    [5e-01,5e+00]
 Objective range [5e-01,2e+00]
 Bounds range    [0e+00,0e+00]
 RHS range       [4e-15,8e+06]
 Dynamism Variables: 1e+01
 Dynamism Rows     : 1e+01
set presolve.tlim = 5
set presolve.totaltlim = 10
Please turn off the presolvers substitution and sparsify and componentsdetection to use dual-postsolving
Continuing without dual-presolve

starting presolve of problem degme.mps with dual-postsolve de-activated
  rows:     185501
  columns:  659415
  int. columns:  0
  cont. columns:  659415
  nonzeros: 8127528

round 0   ( Trivial  ):    0 del cols,    0 del rows,    0 chg bounds,    0 chg sides,    0 chg coeffs,    0 tsx applied,    0 tsx conflicts
round 1   (   Fast   ):    0 del cols,    0 del rows, 624079 chg bounds,    0 chg sides,    0 chg coeffs, 1248158 tsx applied,    0 tsx conflicts
round 2   (Exhaustive):    0 del cols,    0 del rows, 669661 chg bounds,    0 chg sides,    0 chg coeffs, 1387872 tsx applied,    0 tsx conflicts
activating delayed presolvers
round 3   (  Final   ):    0 del cols,    0 del rows, 673671 chg bounds, 5140 chg sides, 71649 chg coeffs, 1401208 tsx applied, 55325 tsx conflicts

          presolver     nb calls   success calls(%)    nb transactions     tsx applied(%)  execution time(s) 
       colsingleton            3                0.0                  0                0.0              0.000
    coefftightening            0                0.0                  0                0.0              0.000
        propagation            3              100.0            1398390              100.0              0.115
      fixcontinuous            1                0.0                  0                0.0              0.005
      simpleprobing            0                0.0                  0                0.0              0.000
       parallelrows            1                0.0                  0                0.0              0.067
       parallelcols            1                0.0                  0                0.0              0.176
           stuffing            1                0.0                  0                0.0              0.000
            dualfix            1                0.0                  0                0.0              0.052
       simplifyineq            0                0.0                  0                0.0              0.000
        doubletoneq            1                0.0                  0                0.0              0.010
            implint            0                0.0                  0                0.0              0.000
             domcol            1                0.0                  0                0.0              0.082
          dualinfer            1                0.0                  0                0.0              0.473
            probing            0                0.0                  0                0.0              0.000
       substitution            1                0.0                  0                0.0              0.511
           sparsify            1              100.0              58143                4.8              0.636

reduced problem:
  reduced rows:     185501
  reduced columns:  659415
  reduced int. columns:  0
  reduced cont. columns:  659415
  reduced nonzeros: 8121222

presolving finished after 10.170 seconds

reduced problem written to reduced_degme.mps in 3.343 seconds

```