### PR TITLE
Fix out of bounds access when the presolver is interrupted

### DIFF
--- a/src/papilo/core/Presolve.hpp
+++ b/src/papilo/core/Presolve.hpp
@@ -1275,7 +1275,7 @@ Presolve<REAL>::applyPostponed( ProblemUpdate<REAL>& probUpdate, const Timer& pr
 {
    probUpdate.setPostponeSubstitutions( false );
 
-   for( int presolver = 0; presolver != (int) postPonedReductionToPresolver.size() - 1; ++presolver )
+   for( int presolver = 0; presolver != (int) postponedReductionToPresolver.size() - 1; ++presolver )
    {
       int first = postponedReductionToPresolver[presolver];
       int last = postponedReductionToPresolver[presolver + 1];

--- a/src/papilo/core/Presolve.hpp
+++ b/src/papilo/core/Presolve.hpp
@@ -1275,7 +1275,7 @@ Presolve<REAL>::applyPostponed( ProblemUpdate<REAL>& probUpdate, const Timer& pr
 {
    probUpdate.setPostponeSubstitutions( false );
 
-   for( int presolver = 0; presolver != (int) presolvers.size(); ++presolver )
+   for( int presolver = 0; presolver != (int) postPonedReductionToPresolver.size() - 1; ++presolver )
    {
       int first = postponedReductionToPresolver[presolver];
       int last = postponedReductionToPresolver[presolver + 1];


### PR DESCRIPTION

This fixes an out of bounds issue when the postponed presolvers are interrupted.  