### PR TITLE
Eliminate empty rows that does not have an activity change

### DIFF
--- a/src/papilo/core/ProblemUpdate.hpp
+++ b/src/papilo/core/ProblemUpdate.hpp
@@ -1158,34 +1158,39 @@ ProblemUpdate<REAL>::flush( bool reset_changed_activities )
             } ), current_changed_activities.end() );
    }
 
-   // Some reductions (substitution/probing/sparsify) strip a row's last coefficient as a side effect of
-   // column substitution/fixing without registering an activity change, so the emptied row never reaches
-   // checkChangedActivities() and is left live with a size 0. This mark these empty
-   // rows as redundant so they can be cleaned afterwards.
-   {
-      const Vec<int>& rowSizes = problem.getRowSizes();
-      const Vec<REAL>& lhs = consMatrix.getLeftHandSides();
-      const Vec<REAL>& rhs = consMatrix.getRightHandSides();
-
-      for ( int i = 0; i < rowSizes.size(); ++i )
-      {
-         if (rowSizes[i] == 0 && !rflags[i].test( RowFlag::kRedundant ) )
-         {
-            bool is_lhs_ok = rflags[i].test( RowFlag::kLhsInf ) || num.isFeasLE( lhs[i], REAL(0) );
-            bool is_rhs_ok = rflags[i].test( RowFlag::kRhsInf ) || num.isFeasLE( REAL(0), rhs[i] );
-            if( is_lhs_ok && is_rhs_ok )
-               markRowRedundant( i );
-            else
-               return PresolveStatus::kInfeasible;
-         }
-      }
-   }
-
    // remove constants of fixed columns
    removeFixedCols();
 
    // delete fixed columns and redundant rows form the matrix
    // TODO update locks in delete rows and cols function
+   consMatrix.deleteRowsAndCols( redundant_rows, deleted_cols, activities,
+                                 singletonRows, singletonColumns,
+                                 emptyColumns );
+
+   // Deleting fixed/substituted columns can remove a row's last coefficient.
+   // Such a row does not necessarily have a recorded activity change and can
+   // otherwise remain live until a presolver assumes that every active row is
+   // nonempty.
+   const Vec<int>& rowSizes = problem.getRowSizes();
+   const Vec<REAL>& lhs = consMatrix.getLeftHandSides();
+   const Vec<REAL>& rhs = consMatrix.getRightHandSides();
+   int nrows = problem.getNRows();
+
+   for( int i = 0; i < nrows; ++i )
+   {
+      if( rowSizes[i] != 0 || rflags[i].test( RowFlag::kRedundant ) )
+         continue;
+
+      bool is_lhs_ok = rflags[i].test( RowFlag::kLhsInf ) ||
+                       num.isFeasLE( lhs[i], REAL{ 0 } );
+      bool is_rhs_ok = rflags[i].test( RowFlag::kRhsInf ) ||
+                       num.isFeasLE( REAL{ 0 }, rhs[i] );
+      if( !is_lhs_ok || !is_rhs_ok )
+         return PresolveStatus::kInfeasible;
+
+      markRowRedundant( i );
+   }
+
    consMatrix.deleteRowsAndCols( redundant_rows, deleted_cols, activities,
                                  singletonRows, singletonColumns,
                                  emptyColumns );

--- a/src/papilo/core/ProblemUpdate.hpp
+++ b/src/papilo/core/ProblemUpdate.hpp
@@ -1158,6 +1158,29 @@ ProblemUpdate<REAL>::flush( bool reset_changed_activities )
             } ), current_changed_activities.end() );
    }
 
+   // Some reductions (substitution/probing/sparsify) strip a row's last coefficient as a side effect of
+   // column substitution/fixing without registering an activity change, so the emptied row never reaches
+   // checkChangedActivities() and is left live with a size 0. This mark these empty
+   // rows as redundant so they can be cleaned afterwards.
+   {
+      const Vec<int>& rowSizes = problem.getRowSizes();
+      const Vec<REAL>& lhs = consMatrix.getLeftHandSides();
+      const Vec<REAL>& rhs = consMatrix.getRightHandSides();
+
+      for ( int i = 0; i < rowSizes.size(); ++i )
+      {
+         if (rowSizes[i] == 0 && rflags[i].test( RowFlag::kRedundant ) )
+         {
+            bool is_lhs_ok = rflags[i].test( RowFlag::kLhsInf ) || num.isFeasLE( lhs[i], REAL(0) );
+            bool is_rhs_ok = rflags[i].test( RowFlag::kRhsInf ) || num.isFeasLE( REAL(0), rhs[i] );
+            if( is_lhs_ok && is_rhs_ok )
+               markRowRedundant( i );
+            else
+               return PresolveStatus::kInfeasible;
+         }
+      }
+   }
+
    // remove constants of fixed columns
    removeFixedCols();
 

--- a/src/papilo/core/ProblemUpdate.hpp
+++ b/src/papilo/core/ProblemUpdate.hpp
@@ -1169,7 +1169,7 @@ ProblemUpdate<REAL>::flush( bool reset_changed_activities )
 
       for ( int i = 0; i < rowSizes.size(); ++i )
       {
-         if (rowSizes[i] == 0 && rflags[i].test( RowFlag::kRedundant ) )
+         if (rowSizes[i] == 0 && !rflags[i].test( RowFlag::kRedundant ) )
          {
             bool is_lhs_ok = rflags[i].test( RowFlag::kLhsInf ) || num.isFeasLE( lhs[i], REAL(0) );
             bool is_rhs_ok = rflags[i].test( RowFlag::kRhsInf ) || num.isFeasLE( REAL(0), rhs[i] );

--- a/src/papilo/core/SingleRow.hpp
+++ b/src/papilo/core/SingleRow.hpp
@@ -466,7 +466,8 @@ update_activity_after_coeffchange( REAL collb, REAL colub, ColFlags cflags,
                                    const Num<REAL> num,
                                    ACTIVITYCHANGE&& activityChange )
 {
-   assert( oldcolcoef != newcolcoef );
+   if (oldcolcoef == newcolcoef)
+      return;
 
    if( oldcolcoef * newcolcoef <= 0.0 )
    { // the sign of the coefficient flipped, so the column bounds now contribute

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,7 @@ set(unit_tests
         #ProblemUpdate
         "trivial-presolve-singleton-row"
         "trivial-presolve-singleton-row-pt-2"
+        "flush-removes-row-emptied-by-fixed-columns"
         "clique-row-flag-detection1"
         "clique-row-flag-detection2"
         "clique-row-flag-detection3"

--- a/test/papilo/core/ProblemUpdateTest.cpp
+++ b/test/papilo/core/ProblemUpdateTest.cpp
@@ -22,10 +22,11 @@
 /*                                                                           */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#include "papilo/external/catch/catch_amalgamated.hpp"
 #include "papilo/core/Problem.hpp"
 #include "papilo/core/ProblemBuilder.hpp"
 #include "papilo/core/Reductions.hpp"
+#include "papilo/external/catch/catch_amalgamated.hpp"
+#include "papilo/presolvers/DualInfer.hpp"
 #include "papilo/presolvers/ImplIntDetection.hpp"
 
 namespace papilo
@@ -72,6 +73,45 @@ TEST_CASE( "trivial-presolve-singleton-row-pt-2", "[core]" )
    REQUIRE( problem.getLowerBounds()[2] == 1 );
    REQUIRE( problem.getRowFlags()[1].test( RowFlag::kRedundant ) );
    REQUIRE( problemUpdate.getSingletonCols().size() == 2 );
+}
+
+TEST_CASE( "flush-removes-row-emptied-by-fixed-columns", "[core]" )
+{
+   ProblemBuilder<double> problemBuilder;
+   problemBuilder.setNumRows( 1 );
+   problemBuilder.setNumCols( 3 );
+   problemBuilder.setColLbAll( { 0.0, 0.0, 0.0 } );
+   problemBuilder.setColUbAll( { 0.0, 0.0, 1.0 } );
+   problemBuilder.setObjAll( { 0.0, 0.0, 0.0 } );
+   problemBuilder.setRowLhsAll( { -1.0 } );
+   problemBuilder.setRowRhsAll( { 1.0 } );
+   problemBuilder.addEntryAll( { { 0, 0, 1.0 }, { 0, 1, 1.0 } } );
+
+   Num<double> num{};
+   Message msg{};
+   Problem<double> problem = problemBuilder.build();
+   problem.recomputeAllActivities();
+   Statistics statistics{};
+   PresolveOptions presolveOptions{};
+   PostsolveStorage<double> postsolve{ problem, num, presolveOptions };
+   ProblemUpdate<double> problemUpdate{ problem,         postsolve, statistics,
+                                        presolveOptions, num,       msg };
+
+   problemUpdate.markColFixed( 0 );
+   problemUpdate.markColFixed( 1 );
+   REQUIRE( problem.getRowSizes()[0] == 2 );
+
+   REQUIRE( problemUpdate.flush( true ) == PresolveStatus::kReduced );
+   REQUIRE( problem.getRowFlags()[0].test( RowFlag::kRedundant ) );
+   REQUIRE( problem.getRowSizes()[0] == -1 );
+
+   double time = 0.0;
+   Timer timer{ time };
+   Reductions<double> reductions{};
+   DualInfer<double> dualInfer{};
+   int cause = -1;
+   REQUIRE( dualInfer.execute( problem, problemUpdate, num, reductions, timer,
+                               cause ) == PresolveStatus::kUnchanged );
 }
 
 TEST_CASE( "clique-row-flag-detection1", "[core]" )


### PR DESCRIPTION
When running Papilo presolve, I encounter the following assertion failure in the DualInfer reduction:

```
src/papilo/presolvers/DualInfer.hpp:211: papilo::PresolveStatus papilo::DualInfer<REAL>::execute(const papilo::Problem<REAL>&, const papilo::ProblemUpdate<REAL>&, const papilo::Num<REAL>&, papilo::Reductions<REAL>&, const papilo::Timer&, int&) [with REAL = double]: Assertion `consMatrix.getRowSizes()[i] > 0' failed.

```
Since the input matrix does not have empty rows, it was introduced during one of the previous presolve reductions (sparsify, substitution or probing):
```
[substitution] live-empty row 28: size 0 lhsInf true rhsInf false eq false lhs -0.04893420343679652 rhs -3.799497838990599e-18
[substitution] live-empty row 30: size 0 lhsInf true rhsInf false eq false lhs -0.01475780480417465 rhs 3.799497838990599e-18
[substitution] TOTAL live-empty (non-redundant, size<=0) rows: 2 (DualInfer will assert on the first)
[probing] live-empty row 24: size 0 lhsInf false rhsInf false eq true lhs 8.45853285232799e-18 rhs 8.45853285232799e-18
[probing] TOTAL live-empty (non-redundant, size<=0) rows: 1 (DualInfer will assert on the first)
[DualInfer] LIVE-EMPTY ROW at execute(): row 24 size 0 redundant false lhsInf false rhsInf false eq true lhs 8.45853285232799e-18 rhs 8.45853285232799e-18 | nrows 142 ncols 61
```

As a fix, I added a loop in `flush()` that mark empty rows as redundant, so they can be eliminated in `consMatrix.deleteRowsAndCols(redundant_rows, …)`.